### PR TITLE
fix: Change transliteration in for-loop and while-loop

### DIFF
--- a/for-loop.md
+++ b/for-loop.md
@@ -1,9 +1,10 @@
 ---
 sort: 9
 ---
+
 ## चक्रम् (for loop)
 
->_transliteration: chakram, meaning: round-loop_
+> _transliteration: chakram, meaning: round-loop_
 
 चक्रम् loops are a great way to run code a certain or changing amount of ways in a concise manner. चक्रम् takes in 3 parameters initial value, and condition, and a step size.
 
@@ -15,7 +16,7 @@ For example, here is a for loop that `वद` all of the numbers ० to ९
 {
   # चक्रम् takes in 3 parameters initial value, and condition, and a step size
   वद("अ =",अ);
-}  
+}
 ```
 
 This ends up outputting
@@ -35,7 +36,7 @@ This ends up outputting
 
 ### Viram:
 
-you can stop the चक्रम् loop between the process by using the 
+you can stop the चक्रम् loop between the process by using the
 
 **विराम** (_transliteration: virAm, meaning: stop_) keyword:
 
@@ -43,10 +44,10 @@ you can stop the चक्रम् loop between the process by using the
 # This will print only till ५, it will break after अ = ५
 चक्र(मान अ = ०; अ < १०; अ = अ+ १){
     यदि (अ >= ५){
-        विराम;  # viram is like continue
+        विराम;  # viram is like break
     }
-    वद("अ =>",अ);    
-} 
+    वद("अ =>",अ);
+}
 ```
 
 **output**
@@ -61,18 +62,18 @@ you can stop the चक्रम् loop between the process by using the
 
 ### Agrim:
 
-you can skip the चक्रम् loop between the process by using the 
+you can skip the चक्रम् loop between the process by using the
 
-**विराम** (_transliteration: AgrIm, meaning: skip_) keyword:
+**अग्रिम** (_transliteration: AgrIm, meaning: skip_) keyword:
 
 ```vedic
 # This will print only till ५, it will skip after अ = २
 चक्र(मान अ = ०; अ < ५; अ = अ+ १){
     यदि (अ == २){
-        अग्रिम; # Agrim is like skip
+        अग्रिम; # Agrim is like continue
     }
     वद("अ =>",अ);
-} 
+}
 ```
 
 **output**

--- a/while-loop.md
+++ b/while-loop.md
@@ -1,9 +1,10 @@
 ---
 sort: 10
 ---
+
 ## पर्यन्तम् (while loop)
 
->_transliteration: chakram, meaning: round-loop_
+> _transliteration: Paryantam, meaning: round-loop_
 
 Vedic includes `पर्यन्तम्` loop to execute code repeatedly till it satisfies a specified condition. Unlike `चक्रम्` loop, `पर्यन्तम्` loop only requires condition expression.
 
@@ -16,7 +17,7 @@ For example, here is a for loop that `वद` all of the numbers ० to ९
 {
   वद(अ);
   अ = अ+ १;
-} 
+}
 ```
 
 **Output:**
@@ -30,4 +31,4 @@ For example, here is a for loop that `वद` all of the numbers ० to ९
 ५
 ```
 
-> you can also use **विराम** and **विराम** keyword in पर्यन्तम् aslo same as चक्रम् loop
+> you can also use **विराम** and **अग्रिम** keyword in पर्यन्तम् aslo same as चक्रम् loop


### PR DESCRIPTION
Issue: #21 

Title: Fix Transliteration in For-loop and While-loop 

Description:

1. For loop

    - https://vedic-lang.github.io/for-loop.html#agrim
    - विराम to अग्रिम 

2. While loop

    - https://vedic-lang.github.io/while-loop.html
    - transliteration of पर्यन्तम्: chakram to Paryantam
    - Last line: विराम and विराम  to  विराम and अग्रिम


